### PR TITLE
chore(resync-mailchimp): return status when not found index and set i…

### DIFF
--- a/packages/resync-mailchimp/package.json
+++ b/packages/resync-mailchimp/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "ts-node-dev src/index.ts",
     "dev-worker": "ts-node-dev src/worker.ts",
-    "fake-worker": "ts-node-dev src/fake-worker.ts",
     "dev-clean": "ts-node-dev src/clean.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/src/index.js",

--- a/packages/resync-mailchimp/package.json
+++ b/packages/resync-mailchimp/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev src/index.ts",
     "dev-worker": "ts-node-dev src/worker.ts",
+    "fake-worker": "ts-node-dev src/fake-worker.ts",
     "dev-clean": "ts-node-dev src/clean.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/src/index.js",

--- a/packages/resync-mailchimp/src/client-elasticsearch.ts
+++ b/packages/resync-mailchimp/src/client-elasticsearch.ts
@@ -10,8 +10,7 @@ export const clientES =
     auth: {
       username: "elastic",
       password: process.env.ELASTICSEARCH_PASSWORD || 'changeme'
-    },
-    context: process.env.NODE_ENV || 'development'
+    }
   });
 
-  export const nameIndex = process.env.NODE_ENV === 'development'? `resync-mailchimp-dev`:`resync-mailchimp`;
+  export const nameIndex = process.env.NODE_ENV === 'production'? `resync-mailchimp`:`resync-mailchimp-dev`;

--- a/packages/resync-mailchimp/src/client-elasticsearch.ts
+++ b/packages/resync-mailchimp/src/client-elasticsearch.ts
@@ -3,12 +3,15 @@ import dotenv from "dotenv";
 dotenv.config();
 
 export const clientES =
-    new Client({
+    new Client({ 
     cloud: {
       id: process.env.ELASTICSEARCH_CLOUD_ID || 'name:bG9jYWxob3N0JGFiY2QkZWZnaA=='
     },
     auth: {
       username: "elastic",
       password: process.env.ELASTICSEARCH_PASSWORD || 'changeme'
-    }
+    },
+    context: process.env.NODE_ENV || 'development'
   });
+
+  export const nameIndex = process.env.NODE_ENV === 'development'? `resync-mailchimp-dev`:`resync-mailchimp`;

--- a/packages/resync-mailchimp/src/index.ts
+++ b/packages/resync-mailchimp/src/index.ts
@@ -43,14 +43,21 @@ app.post('/status-resync-mailchimp', async (req, res) => {
         return res.json(status);
        
     } catch(err: any){
-        let status = err.body;
-
+       
         //index de ressincronização não foi criado 
         if(err.body.status = 404){
-          status = "Parada"
+          return res.json({
+            status: "Parada",
+            last_sync:  "",
+            completed : 0,
+            waiting: 0, 
+            failed: 0, 
+            active: 0
+          });        
         }
+
         return res.status(err.body.status).json({
-          status,
+          status: `${err}`,
           last_sync:  "",
           completed : 0,
           waiting: 0, 

--- a/packages/resync-mailchimp/src/index.ts
+++ b/packages/resync-mailchimp/src/index.ts
@@ -43,7 +43,20 @@ app.post('/status-resync-mailchimp', async (req, res) => {
         return res.json(status);
        
     } catch(err: any){
-        return res.status(err.body.status).json(`${err}`);
+        let status = err.body;
+
+        //index de ressincronização não foi criado 
+        if(err.body.status = 404){
+          status = "Parada"
+        }
+        return res.status(err.body.status).json({
+          status,
+          last_sync:  "",
+          completed : 0,
+          waiting: 0, 
+          failed: 0, 
+          active: 0
+        });        
     }   
 });
 

--- a/packages/resync-mailchimp/src/start-resync-mailchimp.ts
+++ b/packages/resync-mailchimp/src/start-resync-mailchimp.ts
@@ -4,7 +4,7 @@ import { queueContacts, actionTable, dbPool } from "./utils";
 import { Pool, PoolClient } from "pg";
 import log, { apmAgent } from "./dbg";
 import { Table,Contact } from "./types";
-import { clientES } from "./client-elasticsearch";
+import { clientES, nameIndex} from "./client-elasticsearch";
 const JSONStream = require('JSONStream');
 
 /**
@@ -59,12 +59,12 @@ export async function startResyncMailchimpHandle(id: number, is_community: boole
             if(is_community){
                 condition  =  `c.id = ${id}`;
                 prefix = `COMMUNITY${id}WIDGET`; 
-                index =`resync-mailchimp-community-${id}`;
+                index =`${nameIndex}-community-${id}`;
     
             }else{
                 condition =  `w.id = ${id}`;
                 prefix = `WIDGET`; 
-                index = `resync-mailchimp-widget-${id}`; 
+                index = `${nameIndex}-widget-${id}`; 
             }
            
             const query = new QueryStream(`select 

--- a/packages/resync-mailchimp/src/status-resync-mailchimp.ts
+++ b/packages/resync-mailchimp/src/status-resync-mailchimp.ts
@@ -1,11 +1,13 @@
-import { clientES } from "./client-elasticsearch";
+import { clientES, nameIndex } from "./client-elasticsearch";
 import  { format } from "date-fns";
 
 export const statusResyncMailchimpHandle = async (posfix: string) => {
     let counters = { completed : 0, waiting: 0, failed: 0, active: 0 } ; 
+    const index = `${nameIndex}-${posfix}`
+    console.log(index)
     const max_finished_at = await clientES
     .search({
-        index: `resync-mailchimp-${posfix}`,
+        index,
         body: 
           {
             "aggs": {
@@ -21,7 +23,7 @@ export const statusResyncMailchimpHandle = async (posfix: string) => {
       
       let { body } = await clientES.sql.query({
         body: {
-          query: `SELECT status, count(*) total FROM \"resync-mailchimp-${posfix}\" group by status`
+          query: `SELECT status, count(*) total FROM \"${index}\" group by status`
         }
       })  
 

--- a/packages/resync-mailchimp/src/worker.ts
+++ b/packages/resync-mailchimp/src/worker.ts
@@ -2,7 +2,7 @@ import log, { apmAgent } from "./dbg";
 import mailchimp from "./mailchimp-subscribe";
 import { queueContacts, dbPool } from "./utils";
 import dotenv from "dotenv";
-import { clientES } from "./client-elasticsearch";
+import { clientES, nameIndex } from "./client-elasticsearch";
 
 dotenv.config();
 
@@ -41,7 +41,7 @@ export async function startResyncMailchimp() {
             const posfix = job.id.toString().indexOf('COMMUNITY') !== -1?`community-${upContact.community_id}`
               :`widget-${upContact.widget_id}`; 
             clientES.index({
-              index: `resync-mailchimp-${posfix}`,
+              index: `${nameIndex}-${posfix}`,
               method: "PUT",
               id: job.id.toString(),
               body: upContact


### PR DESCRIPTION
### Descrição
Alteração para visualizar os status quando não encontra o index da comunidade no elasticsearch ao invés de erro

- [X] Tratar o retorno no status quando o erro for 404
- [X] Determinar um prefixo diferente para index de ressincronização criados em teste 